### PR TITLE
Output:

### DIFF
--- a/agilerl/components/replay_buffer.py
+++ b/agilerl/components/replay_buffer.py
@@ -165,9 +165,9 @@ class ReplayBuffer:
         :param *args: Variable length argument list. Contains batched transition elements in consistent order,
             e.g. states, actions, rewards, next_states, dones
         """
-        for transition in zip(*args):
-            self._add(*transition)
-            self.counter += 1
+        experiences_to_add = [self.experience(*transition) for transition in zip(*args)]
+        self.memory.extend(experiences_to_add)
+        self.counter += len(experiences_to_add)
 
     def save_to_memory(self, *args: Any, is_vectorised: bool = False) -> None:
         """Applies appropriate save_to_memory function depending on whether


### PR DESCRIPTION
Optimize ReplayBuffer.save_to_memory_vect_envs

The `save_to_memory_vect_envs` method in the `ReplayBuffer` class was refactored to improve efficiency when saving experiences from vectorized environments.

Previously, the method iterated through each transition from the batched arguments and called `self._add()` individually. The new implementation constructs a list of all `experience` namedtuples first and then uses `self.memory.extend()` to append them to the internal deque. This change reduces Python loop overhead, especially beneficial when the number of parallel environments (`num_envs`) is large. The experience counter is also updated correctly in a single operation.